### PR TITLE
Add abstracts and schedule for MPIE 2025 sessions

### DIFF
--- a/mpie2025/abstracts.html
+++ b/mpie2025/abstracts.html
@@ -176,17 +176,185 @@
                 <div class="w3-center">
                     <h1>Speaker Abstracts</h1>
                     <p class="w3-xlarge w3-text-grey">
-                        MPIE 2025 Conference Panels
+                        MPIE 2025 Conference Sessions
                     </p>
                 </div>
             </div>
         </div>
 
-        <!-- Healthcare Panel -->
+        <!-- Morning Session -->
         <div class="w3-row-padding w3-padding-64 w3-container">
             <div class="w3-content">
                 <div class="w3-center">
-                    <h2>Healthcare Panel</h2>
+                    <h2>Morning Session</h2>
+                </div>
+            </div>
+        </div>
+
+        <!-- Introduction -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Prof Michael Luck</h1>
+                        <p><strong>Introduction</strong></p>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Niel de Beaudrap -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Niel de Beaudrap</h1>
+                        <p><strong>Keynote: Quantum Computation</strong></p>
+                        <h5 class="w3-padding-32">
+                            Quantum computation is a subject that draws together
+                            physics, as the basis of ways that matter and energy
+                            can be used to store information; mathematics, as
+                            the subject which describes the abstractions to
+                            allow us to describe how that information can be
+                            structured at a higher level; and computer science,
+                            as the basis to describe how to work with those
+                            abstractions to perform computation. One particular
+                            issue in quantum computation is the fact that
+                            quantum mechanical systems are sensitive to
+                            environmental influence, which is a challenge for
+                            controlling them well enough to compute. In this
+                            talk, I present a high-level view of one particular
+                            line of research to achieve this, from basic
+                            principles to recently published work.
+                            <br /><br />
+                            I aim to provide a sense of the ways in which
+                            several mathematical concepts play a lively role in
+                            quantum information theory and quantum error
+                            correction. These include random variables,
+                            self-adjoint operators, over-categories, symplectic
+                            vector spaces, finite abelian groups, topology,
+                            homotopy, and string diagrams - in many cases
+                            presented with an accent of the finite field of
+                            order 2, and all with the motivation of figuring out
+                            how to choreograph the behaviour of tiny physical
+                            systems to compute things.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Parsa Rahimi -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Parsa Rahimi</h1>
+                        <p>
+                            <strong
+                                >Hybrid Yb/Ba ion trap quantum computing with
+                                laser free coherent control</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Magnetic field noise reduction for improving
+                            coherence times with a feed forward method.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Mateusz Kupper -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Mateusz Kupper</h1>
+                        <p>
+                            <strong
+                                >Quantum Error Correction: String Diagrams for
+                                Defect-Based Surface Code Computing</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Surface codes are a popular choice for implementing
+                            fault-tolerant quantum computing. Two-qubit gates
+                            may be realised in these codes using only
+                            nearest-neighbour interactions, either by lattice
+                            surgery or by braiding defects around each other.
+                            The effect of lattice surgery operations may be
+                            simply described using the ZX-calculus: a graphical
+                            language that has proven effective for program
+                            design and optimisation. In this work, we formalise
+                            a similar description via the ZX-calculus of defect
+                            braiding, as it is conventionally described. We
+                            define a graphical calculus KNOT, denoting the
+                            logical effects (in the absence of byproduct
+                            operations) of defect braiding in surface codes: we
+                            show how these effects may be described via a
+                            fragment of ZX-calculus which we call the (0,
+                            pi)-fragment. We then use a doubling construction to
+                            define a subtheory of KNOT, more specialised to
+                            standard encoding techniques in the defect braiding
+                            literature. Within this subtheory, we encompass
+                            standard braiding techniques by families of
+                            ribbon-like and tangle-like diagrams, each with
+                            semantics distinct from KNOT, in terms of the (0,
+                            pi)-fragment of ZX diagrams (again in the absence of
+                            byproducts). These subtheories may be used
+                            interoperably, and are each sound and complete for
+                            the (0, pi)-fragment of ZX diagrams. This provides a
+                            starting point to use the formal diagrammatics to
+                            analyse the operational effects of defect braiding
+                            procedures.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Xavier Calmet -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Xavier Calmet</h1>
+                        <p><strong>Black Holes in the Quantum Realm</strong></p>
+                        <h5 class="w3-padding-32">
+                            In this talk, we present recent results
+                            demonstrating that quantum physics is crucial to
+                            make sense of black holes. We explain how modern
+                            methods in quantum field theory can be used to
+                            perform calculations in quantum gravity. Our work is
+                            a first step towards merging quantum physics and
+                            Einstein's theory of general relativity.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- MPIE for Healthcare Applications Panel -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-center">
+                    <h2>'MPIE for Healthcare Applications' Panel</h2>
                 </div>
             </div>
         </div>
@@ -215,6 +383,62 @@
                             work bridges the gap between data science, public
                             health, and social impact — with a focus on creating
                             inclusive, actionable solutions.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Dr Sam Hile -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Dr Sam Hile</h1>
+                        <p><strong>Department:</strong> Physics</p>
+                        <h5 class="w3-padding-32">Bio coming soon.</h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Dr Peter Wijeratne -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Dr Peter Wijeratne</h1>
+                        <p><strong>Department:</strong> Informatics</p>
+                        <p>
+                            <strong>Title:</strong> Probabilistic modelling of
+                            disease progression
+                        </p>
+                        <h5 class="w3-padding-32">
+                            <strong>Abstract:</strong> Disease progression
+                            models are special types of latent variable models
+                            that can infer trajectories of change in patients
+                            with a chronic degenerative condition, such as
+                            Alzheimer's disease. They provide unique insight
+                            into disease biology and staging systems with
+                            individual-level clinical utility. Here I will talk
+                            about some methods, applications, benefits and
+                            limitations of these approaches, and avenues for
+                            future research and collaboration. <br /><br />
+                            <strong>Bio:</strong> Dr. Wijeratne has a background
+                            in physics, engineering, and computer science, which
+                            he uses to make machine learning models, primarily
+                            for healthcare. His current research interests
+                            include developing new probabilistic models of
+                            neurodevelopment and neurodegeneration. Along with
+                            Dr. Ivor Simpson, he leads the Learners of
+                            Interpretable Latent Information (LILI) lab in the
+                            Department of Informatics.
                         </h5>
                     </div>
                     <div class="w3-third w3-center">
@@ -264,37 +488,69 @@
             </div>
         </div>
 
-        <!-- Dr Peter Wijeratne -->
+        <!-- Early Afternoon Session -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-center">
+                    <h2>Early Afternoon Session</h2>
+                </div>
+            </div>
+        </div>
+
+        <!-- Aniruddha Girish Aramanekoppa -->
         <div class="w3-row-padding w3-padding-64 w3-container">
             <div class="w3-content">
                 <div class="w3-row">
                     <div class="w3-twothird">
-                        <h1>Dr Peter Wijeratne</h1>
-                        <p><strong>Department:</strong> Informatics</p>
+                        <h1>Aniruddha Girish Aramanekoppa</h1>
                         <p>
-                            <strong>Title:</strong> Probabilistic modelling of
-                            disease progression
+                            <strong
+                                >Probing the Stellar Populations of Distant
+                                Galaxies using the Balmer Break: Validating
+                                Galaxy Formation Models</strong
+                            >
                         </p>
                         <h5 class="w3-padding-32">
-                            <strong>Abstract:</strong> Disease progression
-                            models are special types of latent variable models
-                            that can infer trajectories of change in patients
-                            with a chronic degenerative condition, such as
-                            Alzheimer's disease. They provide unique insight
-                            into disease biology and staging systems with
-                            individual-level clinical utility. Here I will talk
-                            about some methods, applications, benefits and
-                            limitations of these approaches, and avenues for
-                            future research and collaboration. <br /><br />
-                            <strong>Bio:</strong> Dr. Wijeratne has a background
-                            in physics, engineering, and computer science, which
-                            he uses to make machine learning models, primarily
-                            for healthcare. His current research interests
-                            include developing new probabilistic models of
-                            neurodevelopment and neurodegeneration. Along with
-                            Dr. Ivor Simpson, he leads the Learners of
-                            Interpretable Latent Information (LILI) lab in the
-                            Department of Informatics.
+                            In this investigation, the observed Balmer break
+                            strengths of distant galaxies are compared with
+                            predictions from galaxy formation models. The Balmer
+                            break is a spectral discontinuity that occurs at the
+                            Balmer limit (3645 Å) caused by the ionisation of
+                            the n=2 electrons. This feature is strongest in the
+                            spectra of A-type stars, making it an age sensitive
+                            feature, and thus a highly useful diagnostic for
+                            probing the stellar population of a galaxy. The
+                            break strength is strongly dependent on the age of
+                            the stellar population but can also be influenced by
+                            other physical properties, such as the metallicity
+                            or the star formation history. The recent deployment
+                            of the James Webb Space Telescope has made it
+                            possible to observe the Balmer break for galaxies in
+                            the early Universe. In this project, the Balmer
+                            break strengths of high-redshift galaxies were
+                            measured using the data collected by the NIRSpec
+                            instrument on the James Webb Space Telescope. These
+                            measurements were then compared with predictions
+                            from galaxy formation models. In this study, the
+                            predictions were obtained from the First Light and
+                            Reionization Epoch Simulations (FLARES). The results
+                            showed a reasonably good agreement with the FLARES
+                            predictions, as most of the measurements lie within
+                            the predicted range. The observed break strengths
+                            exhibit a broader distribution than the predictions.
+                            There is also a systematic shift towards smaller
+                            Balmer breaks in the observational data. The
+                            predicted medians were found to be between 3 and 5
+                            standard deviations higher than the observed
+                            medians. This shift can be explained either by the
+                            high-redshift galaxies having lower than expected
+                            Balmer breaks, or through the existence of a
+                            selection bias in the dataset that favours younger
+                            stellar populations. Several possible extensions to
+                            this investigation are suggested, including
+                            extending the measurements to other datasets and
+                            comparing the results with other galaxy formation
+                            models.
                         </h5>
                     </div>
                     <div class="w3-third w3-center">
@@ -304,13 +560,458 @@
             </div>
         </div>
 
-        <!-- Dr Sam Hile -->
+        <!-- Charlotte Robinson -->
         <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
             <div class="w3-content">
                 <div class="w3-row">
                     <div class="w3-twothird">
-                        <h1>Dr Sam Hile</h1>
-                        <p><strong>Department:</strong> Physics</p>
+                        <h1>Charlotte Robinson</h1>
+                        <p>
+                            <strong
+                                >Artificial Intelligence and Animal
+                                Behaviour</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">Abstract coming soon.</h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Nay Newman -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Nay Newman</h1>
+                        <p><strong>Ant Visual Navigation</strong></p>
+                        <h5 class="w3-padding-32">
+                            Many ant species are known to rely on visual
+                            information for navigation during foraging trips,
+                            particularly if other navigational tools are in
+                            conflict or fail. This has been shown experimentally
+                            in the field with desert ant species (Cataglyphis
+                            sp. & Myrmecia sp.) and wood ant species (Formica
+                            rufa). These animals are able to navigate through
+                            harsh desert or complex forest environments
+                            efficiently and effectively with very small brains
+                            to process sensory information and execute
+                            appropriate movements; as well as low resolution
+                            eyes. This project aims to explore the difficulty of
+                            a vision based navigation task with limited visual
+                            input, via image resolution, and limited
+                            computational capacity, via CNN model size, from an
+                            ant's eye perspective.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Renhui Ying -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Renhui Ying</h1>
+                        <p>
+                            <strong
+                                >Applying computer vision tools in monitoring
+                                outdoor animal activities</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Tracking animal activity in outdoor farm
+                            environments is crucial for livestock management,
+                            yet it remains a challenging task due to dynamic
+                            changes in cow appearance, variable lighting and
+                            unpredictable animal movements. Traditional
+                            vision-based systems, while effective indoors, often
+                            fail outdoors as they rely on consistent visual
+                            cues, leading to unstable tracking and poor identity
+                            association. This work introduces TwinTrack, a
+                            multi-object tracking framework designed to address
+                            these challenges. The proposed framework leverages a
+                            Twin-Level Contextual Feature Synthesizer (TLCFS) to
+                            extract both fine-grained visual details and
+                            high-level semantic features, ensuring robustness
+                            under diverse environmental conditions.
+                            Additionally, a Dynamic Long-Term Temporal
+                            Consistency Module (DLTC) improves tracking
+                            stability by mitigating the effects of dynamic
+                            behaviors and scene fluctuations. The application of
+                            TwinTrack to outdoor farm environments demonstrates
+                            its ability to monitor livestock effectively, with
+                            experimental results showing stable, long-term
+                            tracking performance.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Trevor Hewitt -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Trevor Hewitt</h1>
+                        <p>
+                            <strong
+                                >The geometry of visual hallucinations</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Visual hallucinations are commonly reported during
+                            psychedelic experiences, altered states of
+                            consciousness, psychiatric conditions, and
+                            neurological disorders, yet their contents remain
+                            poorly characterized quantitatively. The present
+                            study demonstrates that participants can reliably
+                            recreate visual hallucinations in a format suitable
+                            for quantitative computer-vision analysis. Simple
+                            visual hallucinations of geometric forms comparable
+                            to psychedelic and clinical hallucinations can be
+                            rapidly induced via stroboscopic light stimulation,
+                            representing an ideal paradigm for controlled
+                            quantitative analyses. To leverage this towards
+                            developing a quantitative understanding of the
+                            contents of visual hallucinations, two experiments
+                            were conducted in which over 100 participants were
+                            trained to recreate images of geometric visuals from
+                            hallucinatory and veridical visual experiences
+                            either through freehand drawing (Experiment 1) or a
+                            generative image-recreation interface (Experiment
+                            2). Quantitative analysis revealed systematic
+                            differences in hallucinated geometric forms across
+                            strobe frequencies. These findings support the
+                            theorised effect of stroboscopic frequency on the
+                            content of the induced hallucinations while
+                            challenging current models of their neural
+                            mechanisms. Methods were validated with trials where
+                            participants recreated image stimuli instead of
+                            hallucinations. Image recreation is shown to be a
+                            viable tool for quantitative investigations into the
+                            phenomenology of visual hallucinations. A better
+                            understanding of visual hallucinations could shed
+                            light on how the brain constructs conscious
+                            experiences from sensory input. This research opens
+                            the door for computer-vision-based analyses of
+                            visual experiences across contexts, including
+                            psychedelic experiences and neurological disorders.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Maryam Seraj -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Maryam Seraj</h1>
+                        <p>
+                            <strong
+                                >Development of Haptic Interfaces for Medical
+                                Robots</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Teleoperated medical procedures, such as tissue
+                            cutting, ultrasound scanning, palpation, etc.,
+                            require precise motion control and robust
+                            interaction with complex, uncertain environments.
+                            Delays in communication, unpredictable environments,
+                            limited operator experience, and a mismatch between
+                            human hand precision and the capabilities of robotic
+                            execution are common problems for these processes.
+                            This mismatch is particularly evident in commercial
+                            teleoperated robots, which often exhibit high
+                            inertia, limited actuation power, and low natural
+                            frequencies; factors that reduce their
+                            responsiveness and accuracy during delicate
+                            operations. As a result, task precision,
+                            repeatability, and overall system reliability are
+                            all decreased. Furthermore, employing compliant
+                            controllers such as impedance control presents new
+                            issues. While impedance control increases safety by
+                            allowing the robot to adapt to contact forces, it
+                            also leads to path deviations in directions where
+                            the robot's manipulability is poor. For example,
+                            during tissue cutting, limited actuation capability
+                            in certain directions may lead the robot to deviate
+                            from a straight path, resulting in curved or
+                            inaccurate incisions. These issues get worse in
+                            teleoperation setups, where the operator lacks
+                            direct tactile feedback and may not intuitively
+                            compensate for robot limitations. To address these
+                            challenges, this study proposes a novel framework
+                            that integrates a Fractal Impedance Controller (FIC)
+                            strategy, an admittance controller, and a
+                            custom-designed, high-frequency haptic interface
+                            based on a Coaxial Spherical Parallel Mechanism
+                            (CSPM). By unifying FIC with this active,
+                            task-adaptive interface, the system achieves
+                            compliant interaction without compromising accuracy.
+                            Regardless of operator skill level, the end result
+                            is a more capable and intuitive teleoperated system
+                            that can consistently carry out critical medical
+                            procedures. This framework lays the groundwork for
+                            wider use in any situation requiring high-precision,
+                            dynamic human-robot collaboration, not just medical
+                            applications.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Late Afternoon Session -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-center">
+                    <h2>Late Afternoon Session</h2>
+                </div>
+            </div>
+        </div>
+
+        <!-- Jimena Berni -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Jimena Berni</h1>
+                        <p>
+                            <strong
+                                >Analysis of neuronal activity with graph
+                                method</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            We investigated developmental changes in neuromotor
+                            activity patterns in Drosophila melanogaster larvae
+                            by combining calcium imaging with a novel
+                            graph-based mathematical framework. This allows to
+                            perform relevant quantitative comparisons between
+                            first (L1) and early third (L3) instar larvae. We
+                            found that L1 larvae exhibit higher frequencies of
+                            spontaneous neural activity that fail to propagate,
+                            indicating a less mature neuromotor system. In
+                            contrast, L3 larvae show efficient initiation and
+                            propagation of neural activity along the entire
+                            ventral nerve cord (VNC), resulting in longer
+                            activity chains. The time of chain propagation along
+                            the entire VNC is shorter in L1 than in L3, probably
+                            reflecting the increased length of the VNC. On the
+                            other hand, the time of peristaltic waves through
+                            the whole body during locomotion is much faster in
+                            L3 than in L1, so correlating with higher velocities
+                            and greater dispersal rates. Hence, the VNC-body
+                            interaction determines the characteristics of
+                            peristaltic waves propagation in crawling larvae.
+                            Further, asymmetrical neuronal activity,
+                            predominantly in anterior segments of L3 larvae, was
+                            associated with turning behaviors and enhanced
+                            navigation. These findings illustrate that the
+                            proposed quantitative model provides a systematic
+                            method to analyze neuromotor patterns across
+                            developmental stages, for instance, helping to
+                            uncover the maturation stages of neural circuits and
+                            their role in locomotion.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Giuseppe Castiglione -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Giuseppe Castiglione</h1>
+                        <p>
+                            <strong
+                                >Deep Learning Theory for Learning
+                                Dynamics</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Deep neural networks trained with gradient descent
+                            exhibit varying rates of learning for different
+                            patterns. However, the complexity of fitting models
+                            to data makes direct elucidation of the dynamics of
+                            learned patterns challenging. To circumvent this,
+                            many works have opted to characterize phases of
+                            learning through summary statistics known as order
+                            parameters. In this work, we propose a unifying
+                            framework for constructing order parameters based on
+                            the Neural Tangent Kernel (NTK), in which the
+                            relationship with the data set is more transparent.
+                            In particular, we derive a local approximation of
+                            the NTK for a class of deep regression models
+                            (SIRENs) trained to reconstruct natural images. In
+                            so doing, we analytically connect three seemingly
+                            distinct phase transitions: the emergence of wave
+                            patterns in residuals (a novel observation), loss
+                            rate collapse, and NTK alignment. Our results
+                            provide a dynamical perspective on the observed
+                            biases of SIRENs, and deep image regression models
+                            more generally.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Enrico Caprioglio -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Enrico Caprioglio</h1>
+                        <p>
+                            <strong
+                                >Synergistic information and network
+                                science</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            High-order interdependencies are central features of
+                            complex systems, yet a mechanistic explanation for
+                            their emergence remains elusive. Currently, it is
+                            unknown under what conditions high-order
+                            interdependencies, quantified by the
+                            information-theoretic construct of synergy, emerge
+                            in systems governed by pairwise interactions. For
+                            linear Gaussian systems of arbitrary dimension, we
+                            prove that antibalanced correlational structures are
+                            sufficient for synergy-dominance and that
+                            antibalanced interaction motifs in
+                            Ornstein-Uhlenbeck processes are necessary for
+                            synergy-dominance. We validate the applicability of
+                            these analytical insights in Ising, oscillatory, and
+                            empirical networks. Our results demonstrate that
+                            pairwise interactions alone can give rise to
+                            synergistic information in the absence of explicit
+                            high-order mechanisms, and highlight structural
+                            balance theory as an instrumental conceptual
+                            framework to study high-order interdependencies.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Yidan Xu -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Yidan Xu</h1>
+                        <p>
+                            <strong
+                                >Continuous Assessment of Fear of Falling in
+                                Parkinson's Disease Using Wearable Sensors and
+                                Machine Learning</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Fear of falling (FoF) is a prevalent and
+                            debilitating emotional experience in Parkinson's
+                            disease (PD), affecting 37%-59% of people with PD.
+                            While a certain level of FoF can promote safety,
+                            maladaptive patterns may emerge when self-perceived
+                            FoF does not align with actual balance ability. This
+                            mismatch can lead to either excessive avoidance,
+                            reduced mobility, and psychological distress, or to
+                            inappropriate risk-taking in individuals who
+                            underestimate their fall risk. Despite its
+                            importance, FoF is typically assessed through
+                            retrospective questionnaires at infrequent clinic
+                            visits, which fail to reflect fluctuations in daily
+                            life.
+                            <br /><br />
+                            This research investigates a continuous, real-world
+                            approach to assessing FoF using wearable sensors and
+                            machine learning. A new dataset will be collected
+                            from people with PD in their homes, capturing
+                            multi-day body movement data (e.g., from
+                            accelerometers and gyroscopes) alongside various
+                            self-reported emotional labels including FoF level
+                            over time.
+                            <br /><br />
+                            The study focuses on extracting a range of features,
+                            including statistical and signal-based metrics, gait
+                            variability, turning characteristics,
+                            freezing-related indicators, and movement complexity
+                            measures, to identify movement patterns that are
+                            relevant for the automatic assessment of fear of
+                            falling in people with Parkinson's disease. To
+                            address the limitation of small and scarce datasets,
+                            transfer learning methods will be used by leveraging
+                            related datasets from other people with PD and
+                            healthy populations. The generalisability of models
+                            across subgroups (e.g., disease stage, gender) and
+                            across settings (lab vs home) will also be explored.
+                            <br /><br />
+                            This work aims to support personalised, objective
+                            monitoring of fear of falling in PD, enabling early
+                            intervention and better self-management in everyday
+                            life.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Interdisciplinary Panel -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-center">
+                    <h2>
+                        'Interdisciplinary: Improving Dialogue and
+                        Collaboration' Panel
+                    </h2>
+                </div>
+            </div>
+        </div>
+
+        <!-- Prof Thomas Nowotny -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Prof Thomas Nowotny</h1>
+                        <p><strong>Head of Sussex AI</strong></p>
                         <h5 class="w3-padding-32">Bio coming soon.</h5>
                     </div>
                     <div class="w3-third w3-center">
@@ -320,170 +1021,98 @@
             </div>
         </div>
 
-        <!-- Interdisciplinary Research Panel -->
-        <div class="w3-row-padding w3-padding-64 w3-container">
+        <!-- Dr Aline Amorim Graf -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
             <div class="w3-content">
-                <div class="w3-center">
-                    <h2>Interdisciplinary Research Panel</h2>
-                    <p class="w3-text-grey">Speakers to be announced soon</p>
-                </div>
-            </div>
-        </div>
-
-        <!-- First Grid -->
-        <!-- <div class="w3-row-padding w3-padding-64 w3-container">
-        <div class="w3-content">
-          <div class="w3-row">
-            <div class="w3-twothird">
-              <h1><a href="https://profiles.sussex.ac.uk/p504012-ivor-simpson">Ivor Simpson </a></h1>
-              <p>Machine Learning for Inference in Inverse Problems: Advances and Opportunities</p>
-              <h5 class="w3-padding-32">
-                Ill-posed inverse problems in high-dimensional imaging applications, such as those in medical imaging and
-                computer vision, often lack a definitive ground truth and can challenge traditional inference methods. This
-                talk will explore recent advances where machine learning (ML) has facilitated efficient probabilistic
-                inference in various applications. We will discuss the somewhat empirical nature of these advancements and
-                the biases introduced by ML approaches. Finally, we will identify specific challenges and promising research
-                opportunities in this evolving field.
-              </h5>
-            </div>
-            <div class="w3-third w3-center">
-              <img class="w3-padding-64" style="margin-top:50px;margin-left:20px;width:70%;height:auto;"
-                src="assets/speakers/ivor.jpg">
-            </div>
-          </div>
-        </div>
-      </div> -->
-
-        <!-- Second Grid -->
-        <!-- <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
-        <div class="w3-content">
-          <div class="w3-row">
-            <div class="w3-twothird">
-              <h1><a href="https://profiles.sussex.ac.uk/p260256-yuliya-kyrychko">Yuliya Kyrychko</a></h1>
-              <p>Dynamics of coupled systems with time delays.</p>
-              <h5 class="w3-padding-32">Time delays can arise in various physical, biological, physiological and engineering
-                fields, such as chemical reactions, control systems, and biological systems, among others. Since in many
-                realistic settings, the delays are not constant, it is more applicable to use some distribution of time
-                delays to describe the system's dynamics.
-                In this talk I will review the effects of distributed time delays on the dynamics of coupled systems with
-                applications to modelling of neural networks and epidemic modelling. In particular, I will discuss the
-                effects of two different types of distributed-delay coupling in the system of two mutually coupled Kuramoto
-                oscillators: one where the delay distribution is considered inside the coupling function, and the other
-                where the distribution enters outside the coupling function. I will also consider a globally coupled network
-                of active and inactive oscillators with distributed-delay coupling and show the conditions for aging
-                transition, associated with suppression of oscillations, for several different distributions of time delays.
-              </h5>
-            </div>
-            <div class="w3-third w3-center">
-              <img class="w3-padding-64" style="margin-top:50px;margin-left:20px;width:70%;height:auto;"
-                src="assets/speakers/Yuliya.jpg">
-            </div>
-          </div>
-        </div>
-      </div> -->
-
-        <!-- First Grid -->
-        <!-- <div class="w3-row-padding w3-padding-64 w3-container">
-        <div class="w3-content">
-          <div class="w3-row">
-            <div class="w3-twothird">
-              <h1><a href="https://profiles.sussex.ac.uk/p178720-matthias-keller">Matthias Keller</a></h1>
-              <p>Quantum technology development and applications</p>
-              <h5 class="w3-padding-32">
-                In the last decade, quantum mechanics found its way into many applications by developing technologies based
-                on atomic, photonic or solid-state systems. Ranging from quantum sensing to quantum computing and
-                networking, the Sussex Centre for Quantum Technologies, A University Centre of Excellence, has a leading
-                role in the UK’s quantum technology landscape. The Centre is a multi-disciplinary entity with currently
-                eight research groups from Physics and Informatics. In my presentation, I will show the range of
-                technologies developed at Sussex and discuss important applications. We are developing quantum computers
-                based on trapped atomic ions, ion-photon interfaces for quantum networking and distributed quantum
-                computing, magnetic field sensors, optical atomic clocks, the quantum radar and investigate novel
-                solid-state qubit and their manipulation. In addition, we explore how your understanding of the universe can
-                be furthered by using quantum technologies to measure the neutrino mass and searching for changes in
-                fundamental constants.
-              </h5>
-            </div>
-            <div class="w3-third w3-center">
-              <img class="w3-padding-64" style="margin-top:50px;margin-left:20px;width:70%;height:auto;"
-                src="assets/speakers/matthias.jpg">
-            </div>
-          </div>
-        </div>
-      </div> -->
-
-        <!-- <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
-        <div class="w3-content">
-          <div class="w3-row">
-            <div class="w3-twothird">
-              <h1><a href="https://profiles.sussex.ac.uk/p555178-carlo-tiseo">Carlo Tiseo</a></h1>
-              <p>Exploiting Synchronism To Achieve a More Biomimetic Interaction Control</p>
-              <h5 class="w3-padding-32">
-                There is evidence that animals exploit synchronism to simplify the control of their body and stabilize the
-                interaction with the external environment; however, the mechanisms involved still evade our understanding.
-                Currently, most model-based methods used to control robots and model and track animal behaviour use a
-                projected dynamics optimization to regress the system parameters. Such an approach requires a dynamic
-                reference behaviour and is susceptible to kinematic and representation singularities, making them
-                computationally expensive and limiting their robustness. To address this issue, we have developed a passive
-                controller characterized by a conservative observer, which allows multiple controllers to be superimposed
-                without affecting stability while operating with extreme information delay and running at low controller
-                bandwidth. These methods have been successfully applied in human-robot interaction for industrial, space,
-                and medical robotics. In the future, it is expected that such an approach will allow the development of
-                biomimetic control architectures capable of human-like interaction in complex variegated environments.
-              </h5>
-            </div>
-            <div class="w3-third w3-center">
-              <img class="w3-padding-64" style="margin-top:50px;margin-left:20px;width:70%;height:auto;"
-                src="assets/speakers/carlo.jpg">
-            </div>
-          </div>
-        </div>
-      </div> -->
-
-        <!--
-        <div class="w3-row-padding w3-padding-64 w3-container">
-            <div class="w3-content">
-              <div class="w3-twothird">
-                  <h1>About</h1>
-                  <h5 class="w3-padding-32">
-
-                    </h5>
-                <div class="w3-third w3-center">
-                  <img class="w3-padding-64" style="margin-top:50px;margin-left:20px;width:100%;height:100%;";
-                  src="assets/robot.jpg">
-                </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-          <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
-            <div class="w3-content">
-                <div class="w3-twothird">
-                  <h1>About</h1>
-                  <h5 class="w3-padding-32">
-
-                    </h5>
-                <div class="w3-third w3-center">
-                  <img class="w3-padding-64" style="margin-top:50px;margin-left:20px;width:100%;height:100%;";
-                  src="assets/robot.jpg">
-                </div>
-              </div>
-            </div>
-
-            <div class="w3-row-padding w3-padding-64 w3-container">
-                <div class="w3-content">
-                  <div class="w3-twothird">
-                      <h1>About</h1>
-                      <h5 class="w3-padding-32">
-
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Dr Aline Amorim Graf</h1>
+                        <p>
+                            <strong
+                                >Research Fellow in Materials Physics</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Dr Aline Amorim Graf is a Research Fellow in the
+                            Materials Physics group. Her current work involves
+                            developing and processing nanomaterial inks designed
+                            to tune and exploit their enhanced electrical and
+                            thermal properties. As an Early Career Researcher,
+                            she also worked briefly in the Engineering
+                            department, modelling thermal properties of an
+                            office and the relationship with its occupant's
+                            comfort. She received her PhD from the University of
+                            Sussex for her work on extracting reliable and
+                            statistically significant information from Raman
+                            spectroscopy of two-dimensional nanomaterials.
                         </h5>
-                    <div class="w3-third w3-center">
-                      <img class="w3-padding-64" style="margin-top:50px;margin-left:20px;width:100%;height:100%;";
-                      src="assets/robot.jpg">
                     </div>
-              </div><div></div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
 
- -->
+        <!-- Dr Elizabeth McKenzie -->
+        <div class="w3-row-padding w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Dr Elizabeth McKenzie</h1>
+                        <p>
+                            <strong
+                                >Assistant Director of Strategy and Operations
+                                for the Sussex Centre for Quantum
+                                Technologies</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Elizabeth leads on the Centre's Strategy and
+                            Operations, driving and implementing the activities
+                            that increase our research profile, engagement and
+                            partnerships and develop the researcher community.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Amber Shepherd -->
+        <div class="w3-row-padding w3-light-grey w3-padding-64 w3-container">
+            <div class="w3-content">
+                <div class="w3-row">
+                    <div class="w3-twothird">
+                        <h1>Amber Shepherd</h1>
+                        <p>
+                            <strong
+                                >PhD Student, Ion Trap Cavity-QED and Molecular
+                                Physics (ITCM) group</strong
+                            >
+                        </p>
+                        <h5 class="w3-padding-32">
+                            Amber Shepherd is a PhD student at the University of
+                            Sussex, working in the Ion Trap Cavity-QED and
+                            Molecular Physics (ITCM) group. She is working on an
+                            experiment developing a quantum clock to test
+                            fundamental physics. She has experience of
+                            organising cross-departmental outreach initiatives
+                            including Soapbox Science Brighton and Portslade
+                            Science Fair, and co-founded the MPIE conference
+                            last year to bring together researchers from MPS,
+                            EngInf and the wider faculty.
+                        </h5>
+                    </div>
+                    <div class="w3-third w3-center">
+                        <!-- Placeholder for speaker image -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div
             class="w3-container w3-black w3-center w3-opacity w3-padding-64"
         ></div>


### PR DESCRIPTION
The commit adds extensive content to the conference abstracts page, including:

- Session organization into Morning, Early Afternoon and Late Afternoon
- Complete abstracts for all speakers - New 'MPIE for Healthcare Applications' and Interdisciplinary panels - Details for keynote and regular talks covering quantum computing, medical robotics, AI, and more